### PR TITLE
Corrige o erro de modificar array por referência

### DIFF
--- a/dojos/18-11-2017/index.js
+++ b/dojos/18-11-2017/index.js
@@ -16,9 +16,8 @@ const sortParams = (params) => {
 const minSum = (params) =>
 {
   let newParams = sortParams(params);
-  newParams.pop();
+  newParams = params.slice(0,4);
 
-  console.log(newParams)
   return newParams.reduce((a,b)=>{
     return a+b;
   });
@@ -27,7 +26,7 @@ const minSum = (params) =>
 const maxSum = (params) =>
 {
   let newParams = sortParams(params);
-  newParams.shift();
+  newParams = params.slice(1,5);
 
   return newParams.reduce((a,b)=>{
     return a+b;


### PR DESCRIPTION
Substitui os métodos pop e shift que alteram os arrays por referência.
Como os array são objetos no javascript esses métodos trouxeram um side
effect nos testes